### PR TITLE
Code Labels

### DIFF
--- a/kartfire/Leaderboard.py
+++ b/kartfire/Leaderboard.py
@@ -29,10 +29,10 @@ class Leaderboard():
 		self._collection = self._db.get_testcase_collection(collection_name)
 		self._leaderboard = self._db.get_leaderboard(collection_name)
 		for entry in self._leaderboard:
-			filetypes = entry["source_metadata"]["meta"]["filetypes"]
+			filetypes = entry["source_metadata"]["meta"]["code_summary"]["info"]
 			(entry["loc"], entry["language_breakdown"], entry["language_breakdown_text"]) = self._pgm_language_breakdown(filetypes)
 			entry["reltime"] = entry["min_runtime_secs"] / self._collection.reference_runtime_secs
-			entry["code_labels"] = entry["source_metadata"]["meta"]["code_labels"]
+			entry["code_labels"] = entry["source_metadata"]["meta"]["code_summary"]["labels"]
 
 	@property
 	def collection(self):

--- a/kartfire/Leaderboard.py
+++ b/kartfire/Leaderboard.py
@@ -32,6 +32,7 @@ class Leaderboard():
 			filetypes = entry["source_metadata"]["meta"]["filetypes"]
 			(entry["loc"], entry["language_breakdown"], entry["language_breakdown_text"]) = self._pgm_language_breakdown(filetypes)
 			entry["reltime"] = entry["min_runtime_secs"] / self._collection.reference_runtime_secs
+			entry["code_labels"] = entry["source_metadata"]["meta"]["code_labels"]
 
 	@property
 	def collection(self):
@@ -89,6 +90,7 @@ class Leaderboard():
 				"min_runtime_secs": entry["min_runtime_secs"],
 				"loc_by_language": entry["language_breakdown"].most_common(3),
 				"loc": entry["loc"],
+				"code_labels": entry["code_labels"],
 			}
 
 		return {

--- a/kartfire/Submission.py
+++ b/kartfire/Submission.py
@@ -53,7 +53,7 @@ class Submission():
 		if os.path.isfile(json_filename):
 			with open(json_filename) as f:
 				meta["json"] = json.load(f)
-		meta["filetypes"] = MiscTools.determine_lines_by_file_extension(self._submission_dir)
+		meta["filetypes"], meta["code_labels"] = MiscTools.determine_lines_by_file_extension(self._submission_dir, self._test_fixture_config.code_labels)
 		return meta
 
 	@property

--- a/kartfire/Submission.py
+++ b/kartfire/Submission.py
@@ -53,7 +53,7 @@ class Submission():
 		if os.path.isfile(json_filename):
 			with open(json_filename) as f:
 				meta["json"] = json.load(f)
-		meta["filetypes"], meta["code_labels"] = MiscTools.determine_lines_by_file_extension(self._submission_dir, self._test_fixture_config.code_labels)
+		meta["code_summary"] = MiscTools.analyze_files_by_file_extension(self._submission_dir, self._test_fixture_config.code_labels).to_dict()
 		return meta
 
 	@property

--- a/kartfire/TestFixtureConfig.py
+++ b/kartfire/TestFixtureConfig.py
@@ -100,3 +100,7 @@ class TestFixtureConfig():
 	@property
 	def email_via_uri(self):
 		return self.email["via_uri"]
+
+	@property
+	def code_labels(self):
+		return self._config.get("code_labels", { })

--- a/kartfire_test_fixture.json
+++ b/kartfire_test_fixture.json
@@ -14,5 +14,18 @@
 	"email": {
 		"from": "Kartfire CI/CD <cicd@kartfire-pipeline.org>",
 		"via_uri": "file:///tmp/foobar.txt"
-	}
+	},
+   "code_labels": {
+      ".rs": {
+         "unsafe {": "unsafe",
+         "x86_64::": "CPU-intrinsics",
+         "asm!(": "inline-assembly"
+      },
+      ".py": {
+         "ctypes": "C-extension"
+      },
+      ".c": {
+         "__asm__": "inline-assembly"
+      }
+   }
 }


### PR DESCRIPTION
Some programming languages allow quite a few interesting things, that can change the runtime of different solutions in the same programming language. 

In rust this could be `unsafe` code, using inline assembly or using x86 CPU intrinsics such as `pclmulqdq`. Adding labels for these such can help comparing different solutions as it would make the usage of such specials visible. 

I added a few of such cases to `kartfire_test_fixture.json` (also for `C` and `Python`). 

The source of each submission is scanned depending on if the file extension is inside the `code_labels` element from the fixture. Currently it only checks whether the provided keywords appear in the source code, for a more robust option, I could also change this to regex matching but this could be quite a bit slower (but would allow catching the `bin(something)[2:]` crime -- or the hex equivalent).

An entry in the leaderboard export would then contain for example the following:
```json
          "code_labels": ["unsafe", "CPU intrinsics"]
```

What do you think about this?